### PR TITLE
Fixed Mongo config name

### DIFF
--- a/Cdms.Backend.Data/Extensions/ServiceCollectionExtensions.cs
+++ b/Cdms.Backend.Data/Extensions/ServiceCollectionExtensions.cs
@@ -9,7 +9,7 @@ namespace Cdms.Backend.Data.Extensions
 {
     public class MongoDbOptions
     {
-        public const string SectionName = nameof(MongoDbOptions);
+        public const string SectionName = "Mongo";
 
         [Required] public string DatabaseUri { get; set; }
 

--- a/CdmsBackend/appsettings.Development.json
+++ b/CdmsBackend/appsettings.Development.json
@@ -11,7 +11,7 @@
   //},
   "OTEL_EXPORTER_OTLP_ENDPOINT": "http://aspire-dashboard.localtest.me:18889",
   "OTEL_SERVICE_NAME": "Cdms",
-  "MongoDbOptions": {
+  "Mongo": {
     "DatabaseUri": "mongodb://127.0.0.1:27017?retryWrites=false",
     "DatabaseName": "cdms-backend"
   },


### PR DESCRIPTION
Updated the section name in the config back to the default "Mongo" so the connection string gets correctly injected during deployment